### PR TITLE
EC2サーバ側でのRails起動の為

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: freemarket_sample_54a_production
-  username: freemarket_sample_54a
-  password: <%= ENV['FREEMARKET_SAMPLE_54A_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
#WHAT
デプロイ作業に必要

#WHY
EC2サーバ側でのRails起動の為